### PR TITLE
Indent `pegasos` a bit more in the docstring

### DIFF
--- a/src/Perceptron/Perceptron.jl
+++ b/src/Perceptron/Perceptron.jl
@@ -328,7 +328,7 @@ end
 
 
 """
- pegasos(x,y;θ,θ₀,λ,η,T,nMsgs,shuffle,forceOrigin,returnMeanHyperplane)
+    pegasos(x,y;θ,θ₀,λ,η,T,nMsgs,shuffle,forceOrigin,returnMeanHyperplane)
 
 Train the multiclass classifier "pegasos" algorithm according to x (features) and y (labels)
 


### PR DESCRIPTION
This fixes the weird looking method signature at https://sylvaticus.github.io/BetaML.jl/stable/Perceptron.html#BetaML.Perceptron.pegasos-Tuple{Any,%20Any}.