### PR TITLE
Adapt to new `AbstractTrees.AbstractNode` type

### DIFF
--- a/src/Trees/AbstractTrees.jl
+++ b/src/Trees/AbstractTrees.jl
@@ -11,27 +11,24 @@ For more information see [JuliaAI/DecisionTree.jl](https://github.com/JuliaAI/De
 The file `src/abstract_trees.jl` in that repo serves as a model implementation.
 """
 
-export InfoNode, InfoLeaf, wrap, AbstractTree
-
-#### temporal construct until an `AbstractTree` type is available elsewhere
-abstract type AbstractTree end      # will be placed elsewhere in the future
-
-####
+export InfoNode, InfoLeaf, wrap, DecisionNode, Leaf
 
 """
 These types are introduced so that additional information currently not present in 
 a `DecisionTree`-structure -- namely the feature names  -- 
 can be used for visualization.
 """
-struct InfoNode{T} <: AbstractTree
+struct InfoNode{T} <: AbstractTrees.AbstractNode{DecisionNode{T}}
     node    :: DecisionNode{T}
     info    :: NamedTuple
 end
+AbstractTrees.nodevalue(n::InfoNode) = n.node
 
-struct InfoLeaf{T} <: AbstractTree
+struct InfoLeaf{T} <: AbstractTrees.AbstractNode{Leaf{T}}
     leaf    :: Leaf{T}
     info    :: NamedTuple
 end
+AbstractTrees.nodevalue(l::InfoLeaf) = l.leaf
 
 """
     wrap(node:: DecisionNode, ...)

--- a/src/Trees/Trees.jl
+++ b/src/Trees/Trees.jl
@@ -23,7 +23,7 @@ Acknowlegdments: originally based on the [Josh Gordon's code](https://www.youtub
 module Trees
 
 using LinearAlgebra, Random, Statistics, Reexport, CategoricalArrays, DocStringExtensions
-using AbstractTrees
+import AbstractTrees
 
 using  ForceImport
 @force using ..Api


### PR DESCRIPTION
As there is now an abstract type `AbstractNode` in the `AbstractTrees.jl`-package, the implementation of the `AbstractTrees`-interface (in `src/Trees/AbstractTrees.jl`) could be adapted accordingly, so that it is now possible to plot a decision tree using the `TreeRecipe.jl` plot recipe.

There is an example on how to plot a BetaML decision tree using the recipe in `TreeRecipe.jl/test/testBetaMLtrees.jl`.

Note: `TreeRecipe.jl` isn't yet a registered package. So it has to be loaded currently from `roland-KA/TreeRecipe.jl`. 