### PR TITLE
correct typo in `AbstractTrees.printnode`

### DIFF
--- a/src/Trees/AbstractTrees_BetaML_interface.jl
+++ b/src/Trees/AbstractTrees_BetaML_interface.jl
@@ -59,7 +59,7 @@ function AbstractTrees.printnode(io::IO, node::InfoNode)
     q = node.node.question
     condition = isa(q.value, Number) ?  ">=" : "=="
     col = :featurenames ∈ keys(node.info) ? node.info.featurenames[q.column] : q.column
-    print(io, "$(col) $condition $(q.value))?")
+    print(io, "$(col) $condition $(q.value)?")
 end
 
 function AbstractTrees.printnode(io::IO, leaf::InfoLeaf) 


### PR DESCRIPTION
`printnode` added one (superfluous) closing bracket when printing a condition. 